### PR TITLE
manage credits earned by the plateform with validated_at field in travels' table

### DIFF
--- a/back/adminSpaceBack.php
+++ b/back/adminSpaceBack.php
@@ -4,6 +4,7 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 require_once "../class/User.php";
+require_once "../class/Travel.php";
 
 $administrator = new User($pdo, $_SESSION['user_id']);
 

--- a/class/Reservation.php
+++ b/class/Reservation.php
@@ -152,9 +152,8 @@ class Reservation
             $travel = new Travel($pdo, $travelId);
             $travel->setTravelStatus('ended', $travelId);
 
-            //substract 2 credits to driver and and add 2 credits to admin
+            //substract 2 credits to driver
             $this->setCreditToUser($pdo, $this->getDriverIdFromReservation($pdo, $reservationId), -2);
-            $this->setCreditToUser($pdo, $this->getIdAdmin($pdo), +2);
         }
     }
 
@@ -197,9 +196,8 @@ class Reservation
                 $travel = new Travel($pdo, $travelId);
                 $travel->setTravelStatus('ended', $travelId);
 
-                //substract 2 credits to driver and and add 2 credits to admin
+                //substract 2 credits to driver
                 $this->setCreditToUser($pdo, $this->getDriverIdFromReservation($pdo, $reservationId), -2);
-                $this->setCreditToUser($pdo, $this->getIdAdmin($pdo), +2);
             }
 
         } catch (Exception $e) {
@@ -333,15 +331,6 @@ class Reservation
         return (int) $statement->fetchColumn();
     }
 
-    private function getIdAdmin($pdo)
-    {
-        $sql = 'SELECT id FROM users WHERE id_role = 5';
-        $statement = $pdo->prepare($sql);
-        $statement->execute();
-        $roleIdAdmin = $statement->fetch(PDO::FETCH_ASSOC);
-        return (int) $roleIdAdmin['id'];
-    }
-
     private function setCreditToUser($pdo, $userId, $creditToSent)
     {
         $sql = 'UPDATE users SET credit=credit+:creditToSent WHERE id = :userId';
@@ -353,7 +342,6 @@ class Reservation
         } catch (Exception $e) {
             new Exception("Erreur lors de la mise à jour des crédits de l'utilisateur : " . $e->getMessage());
         }
-
     }
 
     private function setValidate($pdo, $reservationId)

--- a/templates/adminSpace.php
+++ b/templates/adminSpace.php
@@ -127,7 +127,8 @@
             <div class="block-light-grey flex-column gap-12 flex-center text-bold"
                 style="width:fit-content;  align-items: center;">
                 <span class="text-green">Crédits gagnés par la plateforme</span>
-                <span class="font-size-very-big "><?= $administrator->getCredit(); ?></span>
+                <?php $travels = new Travel($pdo); ?>
+                <span class="font-size-very-big "><?= $travels->getCreditsEarned(); ?></span>
             </div>
             <div class="block-light-grey flex-column gap-12 flex-center text-bold"
                 style="width:fit-content;  align-items: center;">


### PR DESCRIPTION
When a travel is ended -> the field "validated_at" is updated with current date in the travels' table
![image](https://github.com/user-attachments/assets/9edc1ba6-98f2-4355-9c94-bed4c5c678d0)

Credits earned by the plateform is calculate thanks to this field (count(validated_at) * 2)

![image](https://github.com/user-attachments/assets/e1a6bd26-5423-4d4e-898f-a295f8ee37cc)
